### PR TITLE
Track Go library dependencies so that builds are repeatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 release
 dockser
+.godeps/

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,21 @@
+## main
+github.com/fsouza/go-dockerclient 949b65236a770c3bd15126e9047a41462bb24811
+github.com/coreos/go-etcd/etcd    6fe04d580dfb71c9e34cbce2f4df9eefd1e1241e
+github.com/cenkalti/backoff       6a458ae422d1a8cbfb686ac5f4789bd82956c61b
+github.com/armon/consul-api       1b81c8e0c4cbf1d382310e4c0dc11221632e79d1
+
+## test
+github.com/onsi/ginkgo/ginkgo 90d6a472e25d8096739d5405286ec051c87fade7
+github.com/onsi/gomega        3ca2515afb00bc39bc77d27cdbce85a7caaf103e
+github.com/stretchr/testify   de7fcff264cd05cc0c90c509ea789a436a0dd206
+
+## test codegen
+github.com/vektra/mockery 5e98d9a4390b6c1c9b9f7d326f438b5c3d01a7fc
+
+### transitive deps
+## required by mockery, I think
+github.com/vektra/errors           c64d83aba85aa4392895aadeefabbd24e89f3580
+code.google.com/p/go.tools/imports 7a99b946364f
+
+## required by testify, I think
+github.com/stretchr/objx cbeaeb16a013161a98496fad62933b1d21786672

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,119 @@
+# -*- Makefile -*-
+## the publicly-visible name of your binary
 NAME=registrator
-HARDWARE=$(shell uname -m)
-VERSION=0.3.0
 
-build:
-	mkdir -p stage
-	go build -o stage/registrator
+## the go-get'able path
+PKG_PATH=github.com/blalor/$(NAME)
+
+## version, taken from Git tag (like v1.0.0) or hash
+VER=$(shell git describe --always --dirty | sed -e 's/^v//g' )
+
+HARDWARE=$(shell uname -m)
+
+BIN=.godeps/bin
+GPM=$(BIN)/gpm
+GPM_LINK=$(BIN)/gpm-link
+GVP=$(BIN)/gvp
+
+## @todo should use "$(GVP) in", but that fails
+## all non-test source files
+SOURCES=$(shell go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{.}} {{end}}' ./... | sed -e "s@$(PWD)/@@g" )
+
+## all packages in this prject
+PACKAGES=$(shell go list -f '{{.Name}}' ./... )
+
+.PHONY: all devtools deps test build clean rpm release
+
+## targets after a | are order-only; the presence of the target is sufficient
+## http://stackoverflow.com/questions/4248300/in-a-makefile-is-a-directory-name-a-phony-target-or-real-target
+
+all: build
+
+$(BIN) stage:
+	mkdir -p $@
+
+$(GPM): | $(BIN)
+	curl -s -L -o $@ https://github.com/pote/gpm/raw/v1.3.1/bin/gpm
+	chmod +x $@
+
+$(GPM_LINK): | $(BIN)
+	curl -s -L -o $@ https://github.com/elcuervo/gpm-link/raw/v0.0.1/bin/gpm-link
+	chmod +x $@
+
+$(GVP): | $(BIN)
+	curl -s -L -o $@ https://github.com/pote/gvp/raw/v0.1.0/bin/gvp
+	chmod +x $@
+
+.godeps/.gpm_installed: $(GPM) $(GVP) $(GPM_LINK) Godeps
+	test -e .godeps/src/$(PKG_PATH) || $(GVP) in $(GPM) link add $(PKG_PATH) $(PWD)
+	$(GVP) in $(GPM) install
+	touch $@
+
+$(BIN)/ginkgo: .godeps/.gpm_installed
+	$(GVP) in go install github.com/onsi/ginkgo/ginkgo
+	touch $@
+
+$(BIN)/mockery: .godeps/.gpm_installed
+	$(GVP) in go install github.com/vektra/mockery
+	touch $@
+
+## installs dev tools
+devtools: $(BIN)/ginkgo $(BIN)/mockery
+
+## just installs dependencies
+deps: .godeps/.gpm_installed
+
+## run tests
+test: $(BIN)/ginkgo
+	$(GVP) in $(BIN)/ginkgo $(PACKAGES)
+
+## build the binary
+## augh!  gvp shell escaping!!
+## https://github.com/pote/gvp/issues/22
+stage/$(NAME): .godeps/.gpm_installed $(SOURCES) | stage
+	$(GVP) in go build -o $@ -ldflags '-X\ main.version\ $(VER)' -v .
+
+## same, but shorter
+## add "test" target before stage/$(NAME) once there are some tests
+build: stage/$(NAME)
+
+## duh
+clean:
+	rm -rf stage .godeps release
+
+docker: build
 	docker build -t registrator .
 
-release:
-	rm -rf release
-	mkdir release
-	GOOS=linux go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_linux_$(HARDWARE).tgz $(NAME)
-	GOOS=darwin go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz $(NAME)
+release/$(NAME)_$(VER)_linux_$(HARDWARE).tgz:
+	GOOS=linux $(GVP) in go build -o release/$(NAME)
+	cd release && tar -zcf $(NAME)_$(VER)_linux_$(HARDWARE).tgz $(NAME)
 	rm release/$(NAME)
-	echo "$(VERSION)" > release/version
+
+release/$(NAME)_$(VER)_darwin_$(HARDWARE).tgz:
+	GOOS=darwin $(GVP) in go build -o release/$(NAME)
+	cd release && tar -zcf $(NAME)_$(VER)_darwin_$(HARDWARE).tgz $(NAME)
+	rm release/$(NAME)
+
+release: | release/$(NAME)_$(VER)_darwin_$(HARDWARE).tgz release/$(NAME)_$(VER)_linux_$(HARDWARE).tgz
+	echo "$(VER)" > release/VER
 	echo "progrium/$(NAME)" > release/repo
+
 	gh-release
 
-.PHONY: release
+deb rpm: build
+	mkdir -p stage/$@/usr/bin stage/$@/etc
+	
+	cp stage/$(NAME) stage/$@/usr/bin/
+	chmod 555 stage/$@/usr/bin/$(NAME)
+	
+	## config files
+	cp etc/* stage/$@/etc/
+
+	cd stage && fpm \
+	    -s dir \
+	    -t $@ \
+	    -n $(NAME) \
+	    -v $(VER) \
+	    --rpm-use-file-permissions \
+	    -C $@ \
+	    etc usr

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 NAME=registrator
 
 ## the go-get'able path
-PKG_PATH=github.com/blalor/$(NAME)
+PKG_PATH=github.com/progrium/$(NAME)
 
 ## version, taken from Git tag (like v1.0.0) or hash
 VER=$(shell git describe --always --dirty | sed -e 's/^v//g' )


### PR DESCRIPTION
Add dependency management with gpm, and more thorough Makefile.  Based on https://github.com/blalor/go-template.  

I understand dependency management with Go is a controversial topic, but I'm more interested in making stuff work than with dogma.  I think it's important to have some kind of audit trail so that you can find the point where a changed dependency breaks your application.  Having this change in makes me more comfortable using Registrator in my environment.

I attempted to preserve the `release` target, as well as the Docker image build.  Those should still work fine, but only if you're building on Linux, which I am not. :-)