### PR TITLE
RPM packaging and init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 release
 dockser
+.godeps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 release
 dockser
 .godeps/
+target/

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,21 @@
+## main
+github.com/fsouza/go-dockerclient 949b65236a770c3bd15126e9047a41462bb24811
+github.com/coreos/go-etcd/etcd    6fe04d580dfb71c9e34cbce2f4df9eefd1e1241e
+github.com/cenkalti/backoff       6a458ae422d1a8cbfb686ac5f4789bd82956c61b
+github.com/armon/consul-api       1b81c8e0c4cbf1d382310e4c0dc11221632e79d1
+
+## test
+github.com/onsi/ginkgo/ginkgo 90d6a472e25d8096739d5405286ec051c87fade7
+github.com/onsi/gomega        3ca2515afb00bc39bc77d27cdbce85a7caaf103e
+github.com/stretchr/testify   de7fcff264cd05cc0c90c509ea789a436a0dd206
+
+## test codegen
+github.com/vektra/mockery 5e98d9a4390b6c1c9b9f7d326f438b5c3d01a7fc
+
+### transitive deps
+## required by mockery, I think
+github.com/vektra/errors           c64d83aba85aa4392895aadeefabbd24e89f3580
+code.google.com/p/go.tools/imports 7a99b946364f
+
+## required by testify, I think
+github.com/stretchr/objx cbeaeb16a013161a98496fad62933b1d21786672

--- a/Makefile
+++ b/Makefile
@@ -118,5 +118,7 @@ rpm: build
 	    --epoch $(shell git log --format=format:'%ct' --max-count=1 ${PKG_VER} ) \
 	    --pre-install ../etc/rpm-pre-install.sh \
 	    --rpm-use-file-permissions \
+	    --depends consul \
+	    --depends docker-io \
 	    -C rpm \
 	    etc usr

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ NAME=registrator
 PKG_PATH=github.com/progrium/$(NAME)
 
 ## version, taken from Git tag (like v1.0.0) or hash
-VER=$(shell git describe --always --dirty | sed -e 's/^v//g' )
+VER:=$(shell git describe --always --dirty | sed -e 's/^v//g' )
 
-HARDWARE=$(shell uname -m)
+HARDWARE:=$(shell uname -m)
 
 BIN=.godeps/bin
 GPM=$(BIN)/gpm
@@ -17,10 +17,10 @@ GVP=$(BIN)/gvp
 
 ## @todo should use "$(GVP) in", but that fails
 ## all non-test source files
-SOURCES=$(shell go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{.}} {{end}}' ./... | sed -e "s@$(PWD)/@@g" )
+SOURCES:=$(shell go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{.}} {{end}}' ./... | sed -e "s@$(PWD)/@@g" )
 
 ## all packages in this prject
-PACKAGES=$(shell go list -f '{{.Name}}' ./... )
+PACKAGES:=$(shell go list -f '{{.Name}}' ./... )
 
 .PHONY: all devtools deps test build clean rpm release
 

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,119 @@
+# -*- Makefile -*-
+## the publicly-visible name of your binary
 NAME=registrator
-HARDWARE=$(shell uname -m)
-VERSION=0.3.0
 
-build:
-	mkdir -p stage
-	go build -o stage/registrator
+## the go-get'able path
+PKG_PATH=github.com/blalor/$(NAME)
+
+## version, taken from Git tag (like v1.0.0) or hash
+VER=$(shell git describe --always --dirty | sed -e 's/^v//g' )
+
+HARDWARE=$(shell uname -m)
+
+BIN=.godeps/bin
+GPM=$(BIN)/gpm
+GPM_LINK=$(BIN)/gpm-link
+GVP=$(BIN)/gvp
+
+## @todo should use "$(GVP) in", but that fails
+## all non-test source files
+SOURCES=$(shell go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{.}} {{end}}' ./... | sed -e "s@$(PWD)/@@g" )
+
+## all packages in this prject
+PACKAGES=$(shell go list -f '{{.Name}}' ./... )
+
+.PHONY: all devtools deps test build clean rpm release
+
+## targets after a | are order-only; the presence of the target is sufficient
+## http://stackoverflow.com/questions/4248300/in-a-makefile-is-a-directory-name-a-phony-target-or-real-target
+
+all: build
+
+$(BIN) stage:
+	mkdir -p $@
+
+$(GPM): | $(BIN)
+	curl -s -L -o $@ https://github.com/pote/gpm/raw/v1.3.1/bin/gpm
+	chmod +x $@
+
+$(GPM_LINK): | $(BIN)
+	curl -s -L -o $@ https://github.com/elcuervo/gpm-link/raw/v0.0.1/bin/gpm-link
+	chmod +x $@
+
+$(GVP): | $(BIN)
+	curl -s -L -o $@ https://github.com/pote/gvp/raw/v0.1.0/bin/gvp
+	chmod +x $@
+
+.godeps/.gpm_installed: $(GPM) $(GVP) $(GPM_LINK) Godeps
+	test -e .godeps/src/$(PKG_PATH) || $(GVP) in $(GPM) link add $(PKG_PATH) $(PWD)
+	$(GVP) in $(GPM) install
+	touch $@
+
+$(BIN)/ginkgo: .godeps/.gpm_installed
+	$(GVP) in go install github.com/onsi/ginkgo/ginkgo
+	touch $@
+
+$(BIN)/mockery: .godeps/.gpm_installed
+	$(GVP) in go install github.com/vektra/mockery
+	touch $@
+
+## installs dev tools
+devtools: $(BIN)/ginkgo $(BIN)/mockery
+
+## just installs dependencies
+deps: .godeps/.gpm_installed
+
+## run tests
+test: $(BIN)/ginkgo
+	$(GVP) in $(BIN)/ginkgo $(PACKAGES)
+
+## build the binary
+## augh!  gvp shell escaping!!
+## https://github.com/pote/gvp/issues/22
+stage/$(NAME): .godeps/.gpm_installed $(SOURCES) | stage
+	$(GVP) in go build -o $@ -ldflags '-X\ main.version\ $(VER)' -v .
+
+## same, but shorter
+## add "test" target before stage/$(NAME) once there are some tests
+build: stage/$(NAME)
+
+## duh
+clean:
+	rm -rf stage .godeps release
+
+docker: build
 	docker build -t registrator .
 
-release:
-	rm -rf release
-	mkdir release
-	GOOS=linux go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_linux_$(HARDWARE).tgz $(NAME)
-	GOOS=darwin go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz $(NAME)
+release/$(NAME)_$(VER)_linux_$(HARDWARE).tgz:
+	GOOS=linux $(GVP) in go build -o release/$(NAME)
+	cd release && tar -zcf $(NAME)_$(VER)_linux_$(HARDWARE).tgz $(NAME)
 	rm release/$(NAME)
-	echo "$(VERSION)" > release/version
+
+release/$(NAME)_$(VER)_darwin_$(HARDWARE).tgz:
+	GOOS=darwin $(GVP) in go build -o release/$(NAME)
+	cd release && tar -zcf $(NAME)_$(VER)_darwin_$(HARDWARE).tgz $(NAME)
+	rm release/$(NAME)
+
+release: | release/$(NAME)_$(VER)_darwin_$(HARDWARE).tgz release/$(NAME)_$(VER)_linux_$(HARDWARE).tgz
+	echo "$(VER)" > release/VER
 	echo "progrium/$(NAME)" > release/repo
+
 	gh-release
 
-.PHONY: release
+deb rpm: build
+	mkdir -p stage/$@/usr/bin stage/$@/etc
+	
+	cp stage/$(NAME) stage/$@/usr/bin/
+	chmod 555 stage/$@/usr/bin/$(NAME)
+	
+	## config files
+	cp etc/* stage/$@/etc/
+
+	cd stage && fpm \
+	    -s dir \
+	    -t $@ \
+	    -n $(NAME) \
+	    -v $(VER) \
+	    --rpm-use-file-permissions \
+	    -C $@ \
+	    etc usr

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 NAME=registrator
 
 ## the go-get'able path
-PKG_PATH=github.com/blalor/$(NAME)
+PKG_PATH=github.com/progrium/$(NAME)
 
 ## version, taken from Git tag (like v1.0.0) or hash
 VER=$(shell git describe --always --dirty | sed -e 's/^v//g' )

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,1 @@
+Various scripts and config files to support packaging, etc.

--- a/etc/registrator.logrotate
+++ b/etc/registrator.logrotate
@@ -1,0 +1,9 @@
+/var/log/registrator {
+    daily
+    rotate 5
+    copytruncate
+    delaycompress
+    compress
+    notifempty
+    missingok
+}

--- a/etc/rpm-pre-install.sh
+++ b/etc/rpm-pre-install.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-getent passwd reg-ator > /dev/null || /usr/sbin/useradd -r reg-ator
+user="reg-ator"
+
+## create user if it doesn't exist
+getent passwd ${user} > /dev/null || /usr/sbin/useradd -r ${user}
+
+## add user to docker group
+usermod --append --groups docker ${user}
+
 exit 0

--- a/etc/rpm-pre-install.sh
+++ b/etc/rpm-pre-install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+getent passwd reg-ator > /dev/null || /usr/sbin/useradd -r reg-ator
+exit 0

--- a/etc/sysconfig
+++ b/etc/sysconfig
@@ -1,0 +1,9 @@
+# -*- bash -*-
+
+## required
+# REGISTRY_URI
+
+## defaults
+# TTL="0"
+# TTL_REFERSH="0"
+# DOCKER_HOST="unix:///var/run/docker.sock"

--- a/etc/sysvinit.sh
+++ b/etc/sysvinit.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# registrator        Service registry bridge for Docker
+#       
+# chkconfig:   2345 95 95
+# description: Service registry bridge for Docker
+# processname: registrator
+# config: /etc/sysconfig/registrator
+# pidfile: /var/run/registrator.pid
+
+### BEGIN INIT INFO
+# Provides:       registrator
+# Required-Start: $network consul docker
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start: 2 3 4 5
+# Default-Stop:  0 1 6
+# Short-Description: Service registry bridge for Docker
+# Description: Service registry bridge for Docker
+### END INIT INFO
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+prog="registrator"
+user="reg-ator"
+group="docker"
+exec="/usr/bin/$prog"
+pidfile="/var/run/$prog.pid"
+lockfile="/var/lock/subsys/$prog"
+logfile="/var/log/$prog"
+conffile="/etc/sysconfig/$prog"
+
+# pull in sysconfig settings
+[ -e $conffile ] && . $conffile
+
+## defaults
+export GOMAXPROCS=${GOMAXPROCS:-2}
+TTL=${TTL:0}
+TTL_REFERSH=${TTL_REFERSH:-0}
+DOCKER_HOST=${DOCKER_HOST:-"unix:///var/run/docker.sock"}
+
+prestart() {
+    if ! service consul status > /dev/null ; then
+        service consul start
+    fi
+
+    if ! service docker status > /dev/null ; then
+        service docker start
+    fi
+}
+
+
+start() {
+    [ -x $exec ] || exit 5
+    
+    [ -f $conffile ] || exit 6
+
+    umask 077
+
+    touch $logfile $pidfile
+    chown $user:$group $logfile $pidfile
+
+    prestart
+    
+    echo -n $"Starting $prog: "
+    
+    ## holy shell shenanigans, batman!
+    ## go can't be properly daemonized.  we need the pid of the spawned process,
+    ## which is actually done via runuser thanks to --user.
+    ## you can't do "cmd &; action" but you can do "{cmd &}; action".
+    ##
+    ## registrator will not write to stdout except in the case of a runtime
+    ## panic
+    daemon \
+        --pidfile=$pidfile \
+        --user=$user \
+        " { $exec -ttl=${TTL} -ttl-refresh=${TTL_REFERSH} ${REGISTRY_URI} > ${logfile} 2>&1 & } ; echo \$! >| $pidfile "
+    
+    RETVAL=$?
+    
+    if [ $RETVAL -eq 0 ]; then
+        touch $lockfile
+    fi
+    
+    echo    
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    
+    killproc -p $pidfile $prog
+    RETVAL=$?
+
+    if [ $RETVAL -eq 0 ]; then
+        rm -f $lockfile $pidfile
+    fi
+
+    echo
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status -p "$pidfile" -l $prog $exec
+    
+    RETVAL=$?
+    
+    return $RETVAL
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|force-reload}"
+        exit 2
+esac
+
+exit $?

--- a/etc/sysvinit.sh
+++ b/etc/sysvinit.sh
@@ -37,7 +37,7 @@ conffile="/etc/sysconfig/$prog"
 
 ## defaults
 export GOMAXPROCS=${GOMAXPROCS:-2}
-TTL=${TTL:0}
+TTL=${TTL:-0}
 TTL_REFERSH=${TTL_REFERSH:-0}
 DOCKER_HOST=${DOCKER_HOST:-"unix:///var/run/docker.sock"}
 


### PR DESCRIPTION
I know @progrium is mostly targeting registrator toward containerized deployment, but I think in some cases it makes sense to run it as a process on the host running Docker and Consul: running registrator in a container requires configuring Consul to listen on all interfaces which I would like to avoid if possible.

This follows the standard RedHat service template for pre-RHEL7 hosts (ie SysV init script instead of systemd).

It's entirely likely that this doesn't make sense to have in the main Makefile, but I wanted to at least contribute the service script.

This is built on the branch for #48, because it uses that Makefile as a baseline.