### PR TITLE
Remove service on container stop event

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -166,7 +166,6 @@ func (b *RegistryBridge) Add(containerId string) {
 			PortType:    p[1],
 			Container:   container,
 		})
-		// }
 	}
 
 	for _, port := range ports {

--- a/registrator.go
+++ b/registrator.go
@@ -92,7 +92,7 @@ func main() {
 	events := make(chan *dockerapi.APIEvents)
 	assert(docker.AddEventListener(events))
 	log.Println("registrator: Listening for Docker events...")
-	
+
 	// List already running containers
 	containers, err := docker.ListContainers(dockerapi.ListContainersOptions{})
 	assert(err)
@@ -122,6 +122,8 @@ func main() {
 		switch msg.Status {
 		case "start":
 			go bridge.Add(msg.ID)
+		case "stop":
+			go bridge.Remove(msg.ID)
 		case "die":
 			go bridge.Remove(msg.ID)
 		}


### PR DESCRIPTION
Adds a call to `bridge.Remove()` when a container is stopped.