### PR TITLE
Issue59

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Registrator assumes the default Docker socket at `file:///var/run/docker.sock` o
 
 By default, when registering a service, registrator will assign the service address by attempting to resolve the current hostname. If you would like to force the service address to be a specific address, you can specify the `-ip` argument.
 
-If the argument `-internal` is passed, registrator will register the docker0 internal ip and port instead of the host mapped ones. (etcd only for now)
+If the argument `-internal` is passed, registrator will register the docker0 internal ip and port instead of the host mapped ones. (etcd only for now) (Consul backend is also working like this if you change the TYPE container environment to `catalog`)
 
 The consul backend does not support automatic expiry of stale registrations after some TTL. Instead, TTL checks must be configured (see below). For backends that do support TTL expiry, registrator can be started with the `-ttl` and `-ttl-refresh` arguments (both disabled by default).
 
@@ -86,10 +86,12 @@ For each published port of a container, a `Service` object is created and passed
 		Port  int                  // <host-port>
 		IP    string               // <host-ip> || <resolve(hostname)> if 0.0.0.0
 		Tags  []string             // empty, or includes 'udp' if udp
+                Type  string               // 'agent', you can set it to 'catalog'
 		Attrs map[string]string    // any remaining service metadata from environment
 	}
 
-Most of these (except `IP` and `Port`) can be overridden by container environment metadata variables prefixed with `SERVICE_` or `SERVICE_<internal-port>_`. You use a port in the key name to refer to a particular port's service. Metadata variables without a port in the name are used as the default for all services or can be used to conveniently refer to the single exposed service. 
+Most of these (except `IP` and `Port`) can be overridden by container environment metadata variables prefixed with `SERVICE_` or `SERVICE_<internal-port>_`. You use a port in the key name to refer to a particular port's service. Metadata variables without a port in the name are used as the default for all services or can be used to conveniently refer to the single exposed service.
+If you set the Type to `catalog` then new node is created with the given hostname and the services registered under it. In case of `internal` mode the published IP and Port are registered for the service. In this mode there is no check!
 
 Additional supported metadata in the same format `SERVICE_<metadata>`.
 IGNORE: Any value for ignore tells registrator to ignore this entire container and all associated ports.
@@ -108,6 +110,7 @@ Results in `Service`:
 		"Port": 10000,
 		"IP": "192.168.1.102",
 		"Tags": [],
+                "Type": "agent",
 		"Attrs": {}
 	}
 
@@ -126,10 +129,11 @@ Results in `Service`:
 		"Port": 10000,
 		"IP": "192.168.1.102",
 		"Tags": ["master", "backups"],
+                "Type": "agent",
 		"Attrs": {"region": "us2"}
 	}
 
-Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use. 
+Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use.
 
 ### Multiple services with defaults
 
@@ -144,6 +148,7 @@ Results in two `Service` objects:
 			"Port": 4443,
 			"IP": "192.168.1.102",
 			"Tags": [],
+                        "Type": "agent",
 			"Attrs": {},
 		},
 		{
@@ -152,6 +157,7 @@ Results in two `Service` objects:
 			"Port": 8000,
 			"IP": "192.168.1.102",
 			"Tags": [],
+                        "Type": "agent",
 			"Attrs": {}
 		}
 	]
@@ -174,6 +180,7 @@ Results in two `Service` objects:
 			"Port": 4443,
 			"IP": "192.168.1.102",
 			"Tags": ["www"],
+                        "Type": "agent",
 			"Attrs": {"sni": "enabled"},
 		},
 		{
@@ -182,9 +189,26 @@ Results in two `Service` objects:
 			"Port": 8000,
 			"IP": "192.168.1.102",
 			"Tags": ["www"],
+                        "Type": "agent",
 			"Attrs": {}
 		}
 	]
+
+### Single service with Type catalog in internal mode
+
+	$ docker run -d -h redisNode --name redis.0 -p 10000:6379 -e "SERVICE_TYPE=catalog" dockerfile/redis
+
+Results in `Service`:
+
+	{
+		"ID": "redisNode:redis.0:6379",
+		"Name": "redis",
+		"Port": 6379,
+		"IP": "172.17.0.32",
+		"Tags": [],
+                "Type": "catalog",
+		"Attrs": {}
+	}
 
 ## Adding support for other service registries
 
@@ -211,7 +235,7 @@ This feature is only available when using the `check-http` script that comes wit
 	SERVICE_80_CHECK_HTTP=/health/endpoint/path
 	SERVICE_80_CHECK_INTERVAL=15s
 
-It works for an HTTP service on any port, not just 80. If its the only service, you can also use `SERVICE_CHECK_HTTP`. 
+It works for an HTTP service on any port, not just 80. If its the only service, you can also use `SERVICE_CHECK_HTTP`.
 
 #### Run a health check script in the service container
 

--- a/bridge.go
+++ b/bridge.go
@@ -31,6 +31,7 @@ type Service struct {
 	Tags  []string
 	Attrs map[string]string
 	TTL   int
+	Type  string
 
 	pp PublishedPort
 }
@@ -77,7 +78,11 @@ func NewService(port PublishedPort, isgroup bool) *Service {
 
 	service := new(Service)
 	service.pp = port
-	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
+	if *internal {
+		service.ID = port.HostName + ":" + container.Name[1:] + ":" + port.ExposedPort
+	} else {
+		service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
+	}
 	service.Name = mapdefault(metadata, "name", defaultName)
 	var p int
 	if *internal == true {
@@ -101,6 +106,8 @@ func NewService(port PublishedPort, isgroup bool) *Service {
 	if id != "" {
 		service.ID = id
 	}
+
+	service.Type = mapdefault(metadata, "type", "agent")
 
 	delete(metadata, "id")
 	delete(metadata, "tags")

--- a/bridge.go
+++ b/bridge.go
@@ -31,7 +31,6 @@ type Service struct {
 	Tags  []string
 	Attrs map[string]string
 	TTL   int
-	Type  string
 
 	pp PublishedPort
 }
@@ -106,8 +105,6 @@ func NewService(port PublishedPort, isgroup bool) *Service {
 	if id != "" {
 		service.ID = id
 	}
-
-	service.Type = mapdefault(metadata, "type", "agent")
 
 	delete(metadata, "id")
 	delete(metadata, "tags")

--- a/consul.go
+++ b/consul.go
@@ -30,10 +30,10 @@ func NewConsulRegistry(uri *url.URL) ServiceRegistry {
 
 func (r *ConsulRegistry) Register(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		if service.Type == "agent" {
-			return r.registerWithAgent(service)
-		} else {
+		if *catalog {
 			return r.registerWithCatalog(service)
+		} else {
+			return r.registerWithAgent(service)
 		}
 	} else {
 		return r.registerWithKV(service)
@@ -107,10 +107,10 @@ func (r *ConsulRegistry) registerWithKV(service *Service) error {
 
 func (r *ConsulRegistry) Deregister(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		if service.Type == "agent" {
-			return r.deregisterWithAgent(service)
-		} else {
+		if *catalog {
 			return r.deregisterWithCatalog(service)
+		} else {
+			return r.deregisterWithAgent(service)
 		}
 	} else {
 		return r.deregisterWithKV(service)

--- a/consul.go
+++ b/consul.go
@@ -30,7 +30,7 @@ func NewConsulRegistry(uri *url.URL) ServiceRegistry {
 
 func (r *ConsulRegistry) Register(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		if *catalog {
+		if *internal {
 			return r.registerWithCatalog(service)
 		} else {
 			return r.registerWithAgent(service)
@@ -107,7 +107,7 @@ func (r *ConsulRegistry) registerWithKV(service *Service) error {
 
 func (r *ConsulRegistry) Deregister(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		if *catalog {
+		if *internal {
 			return r.deregisterWithCatalog(service)
 		} else {
 			return r.deregisterWithAgent(service)

--- a/consul.go
+++ b/consul.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"log"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"strconv"
@@ -30,13 +30,37 @@ func NewConsulRegistry(uri *url.URL) ServiceRegistry {
 
 func (r *ConsulRegistry) Register(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		return r.registerWithCatalog(service)
+		if service.Type == "agent" {
+			return r.registerWithAgent(service)
+		} else {
+			return r.registerWithCatalog(service)
+		}
 	} else {
 		return r.registerWithKV(service)
 	}
 }
 
 func (r *ConsulRegistry) registerWithCatalog(service *Service) error {
+	writeOptions := new(consulapi.WriteOptions)
+	regCatalog := new(consulapi.CatalogRegistration)
+	regCatalog.Datacenter = "dc1"
+	regCatalog.Node = service.pp.HostName
+	regCatalog.Address = service.IP
+
+	regCatalog.Service = new(consulapi.AgentService)
+	regCatalog.Service.ID = service.ID
+	regCatalog.Service.Service = service.Name
+	regCatalog.Service.Port = service.Port
+	regCatalog.Service.Tags = service.Tags
+
+	_, err := r.client.Catalog().Register(regCatalog, writeOptions)
+	if err != nil {
+		log.Println("registrator: consul: failed to register catalog service:", err)
+	}
+	return err
+}
+
+func (r *ConsulRegistry) registerWithAgent(service *Service) error {
 	registration := new(consulapi.AgentServiceRegistration)
 	registration.ID = service.ID
 	registration.Name = service.Name
@@ -83,7 +107,11 @@ func (r *ConsulRegistry) registerWithKV(service *Service) error {
 
 func (r *ConsulRegistry) Deregister(service *Service) error {
 	if r.path == "" || r.path == "/" {
-		return r.deregisterWithCatalog(service)
+		if service.Type == "agent" {
+			return r.deregisterWithAgent(service)
+		} else {
+			return r.deregisterWithCatalog(service)
+		}
 	} else {
 		return r.deregisterWithKV(service)
 	}
@@ -94,6 +122,21 @@ func (r *ConsulRegistry) Refresh(service *Service) error {
 }
 
 func (r *ConsulRegistry) deregisterWithCatalog(service *Service) error {
+	writeOptions := new(consulapi.WriteOptions)
+	deregCatalog := new(consulapi.CatalogDeregistration)
+	deregCatalog.Datacenter = "dc1"
+	deregCatalog.Node = service.pp.HostName
+	deregCatalog.Address = service.IP
+	deregCatalog.ServiceID = service.ID
+
+	_, err := r.client.Catalog().Deregister(deregCatalog, writeOptions)
+	if err != nil {
+		log.Println("registrator: consul: failed to deregister catalog service:", err)
+	}
+	return err
+}
+
+func (r *ConsulRegistry) deregisterWithAgent(service *Service) error {
 	return r.client.Agent().ServiceDeregister(service.ID)
 }
 

--- a/registrator.go
+++ b/registrator.go
@@ -17,7 +17,6 @@ var internal = flag.Bool("internal", false, "Use internal ports instead of publi
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
-var catalog = flag.Bool("catalog", false, "Use consul's catalog register instead of agent register")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {

--- a/registrator.go
+++ b/registrator.go
@@ -17,6 +17,7 @@ var internal = flag.Bool("internal", false, "Use internal ports instead of publi
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
+var catalog = flag.Bool("catalog", false, "Use consul's catalog register instead of agent register")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {


### PR DESCRIPTION
This is fix the issue "Consul services seem to be registered under wrong node #59".

I added a new container environment metadata variable SERVICE_TYPE.
* If you set it to `catalog` then new node is created with the given hostname and the services registered under it. 
* In case of `internal` mode the published IP and Port are registered for the service.
* (In case of other mode the working is similar to previous)
* If you not set or set to `agent` then there is no any changes in working.

My english is weak, so maybe need to improve my changes in the README.md.