### PR TITLE
Added canonical import path to main package.

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -1,4 +1,4 @@
-package main
+package main // import "github.com/progrium/registrator"
 
 import (
 	"errors"


### PR DESCRIPTION
In the discussion of #94 it is speculated that just a new build is required as the problem was corrected in an upstream dependency. I came across centurylink/golang-builder, a Docker image for building Go executables and packaging them into a Docker container. The canonical import path needed to be added to the main package in order for it successfully compile and build.